### PR TITLE
Support label in scatter series

### DIFF
--- a/charming/src/series/scatter.rs
+++ b/charming/src/series/scatter.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
-        ColorBy, CoordinateSystem, DimensionEncode, Emphasis, ItemStyle, MarkArea, MarkLine,
+        ColorBy, CoordinateSystem, DimensionEncode, Emphasis, ItemStyle, Label, MarkArea, MarkLine,
         Symbol, SymbolSize,
     },
 };
@@ -19,10 +19,13 @@ pub struct Scatter {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
+    
     #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label: Option<Label>,
+    
     #[serde(skip_serializing_if = "Option::is_none")]
     dataset_index: Option<f64>,
 
@@ -67,6 +70,7 @@ impl Scatter {
             id: None,
             name: None,
             color_by: None,
+            label: None,
             dataset_index: None,
             coordinate_system: None,
             x_axis_index: None,
@@ -97,6 +101,11 @@ impl Scatter {
         self
     }
 
+    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+    
     pub fn dataset_index<F: Into<f64>>(mut self, dataset_index: F) -> Self {
         self.dataset_index = Some(dataset_index.into());
         self


### PR DESCRIPTION
Duplicated from '128ef83' commit, which added label in line series.